### PR TITLE
Fix YouTube quality menu selection

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,7 +6,7 @@ chrome.runtime.onInstalled.addListener(function(details) {
   } else if (details.reason == "update") {
     var version = chrome.runtime.getManifest().version;
     chrome.tabs.create({
-        url: 'https://sameernyaupane.github.io/simple-auto-hd/updated?v=' + version
+        url: chrome.runtime.getURL('docs/updated.html?v=' + version)
     });
   }
 });

--- a/background.js
+++ b/background.js
@@ -6,7 +6,7 @@ chrome.runtime.onInstalled.addListener(function(details) {
   } else if (details.reason == "update") {
     var version = chrome.runtime.getManifest().version;
     chrome.tabs.create({
-        url: 'https://sameernyaupane.github.io/simple-auto-hd/updated?v=2.0.4'
+        url: 'https://sameernyaupane.github.io/simple-auto-hd/updated?v=' + version
     });
   }
 });

--- a/content.js
+++ b/content.js
@@ -191,6 +191,125 @@
         '화질'
     ];
 
+    var menuWaitTimeout = 1500;
+    var menuCloseDelay = 200;
+
+    function normalizeMenuText(text) {
+        return (text || '').replace(/\s+/g, ' ').trim();
+    }
+
+    function isElementVisible(element) {
+        return !!(element && (element.offsetWidth || element.offsetHeight || element.getClientRects().length));
+    }
+
+    function getMenuItemFromLabel(label) {
+        return label.closest('.ytp-menuitem') || label;
+    }
+
+    function waitForValue(getValue, timeout) {
+        return new Promise(function(resolve) {
+            var value = getValue();
+
+            if (value) {
+                resolve(value);
+                return;
+            }
+
+            var endTime = Date.now() + timeout;
+            var interval = setInterval(function() {
+                value = getValue();
+
+                if (value || Date.now() >= endTime) {
+                    clearInterval(interval);
+                    resolve(value || null);
+                }
+            }, 50);
+        });
+    }
+
+    function isSettingsMenuOpen(settingsButton) {
+        var settingsMenu = document.querySelector('.ytp-settings-menu');
+        return (settingsButton && settingsButton.getAttribute('aria-expanded') === 'true') || isElementVisible(settingsMenu);
+    }
+
+    function openSettingsMenu(settingsButton) {
+        if (!isSettingsMenuOpen(settingsButton)) {
+            settingsButton.click();
+        }
+    }
+
+    function closeSettingsMenu(settingsButton) {
+        if (isSettingsMenuOpen(settingsButton)) {
+            settingsButton.click();
+        }
+    }
+
+    function findQualityMenuLabel() {
+        var labels = Array.from(document.querySelectorAll('.ytp-menuitem-label'));
+
+        for (var i = 0; i < labels.length; i++) {
+            var menuItem = getMenuItemFromLabel(labels[i]);
+            var labelText = normalizeMenuText(labels[i].textContent);
+
+            if (isElementVisible(menuItem) && qualityTitles.includes(labelText)) {
+                return labels[i];
+            }
+        }
+
+        return null;
+    }
+
+    function getQualityValue(label) {
+        var labelText = normalizeMenuText(label.textContent);
+        var match = labelText.match(/^(Auto|[0-9]+p(?:[0-9]+)?)/);
+
+        return match ? match[1] : '';
+    }
+
+    function getVisibleQualityLabels() {
+        var labels = Array.from(document.querySelectorAll('.ytp-quality-menu .ytp-menuitem-label'));
+
+        if (labels.length === 0) {
+            labels = Array.from(document.querySelectorAll('.ytp-menuitem-label'));
+        }
+
+        return labels.filter(function(label) {
+            var labelText = normalizeMenuText(label.textContent);
+            var menuItem = getMenuItemFromLabel(label);
+
+            return isElementVisible(menuItem) &&
+                getQualityValue(label) !== '' &&
+                !label.querySelector('.ytp-premium-label') &&
+                !labelText.includes('Premium');
+        });
+    }
+
+    function clickMenuLabel(label) {
+        getMenuItemFromLabel(label).click();
+    }
+
+    function findQualityByName(quality, targetItems) {
+        for (var i = 0; i < targetItems.length; i++) {
+            if (getQualityValue(targetItems[i]) === quality) {
+                return targetItems[i];
+            }
+        }
+
+        return null;
+    }
+
+    function findBestAvailableQuality(targetItems) {
+        for (var i = 0; i < qualitiesArray.length; i++) {
+            var targetItem = findQualityByName(qualitiesArray[i], targetItems);
+
+            if (targetItem) {
+                return targetItem;
+            }
+        }
+
+        return targetItems[0] || null;
+    }
+
     // Inititate observer
     function initiateObserverAndObserve() {
         var observer = new MutationObserver(function (mutations) {
@@ -214,6 +333,12 @@
     // Listen to theater mode button for clicks
     function listenToTheaterModeButton() {
         var sizeButton = document.getElementsByClassName('ytp-size-button')[0];
+
+        if (!sizeButton || sizeButton.dataset.simpleAutoHdTheaterListenerAttached === 'true') {
+            return;
+        }
+
+        sizeButton.dataset.simpleAutoHdTheaterListenerAttached = 'true';
         
         // Listen to theater mode changes
         sizeButton.addEventListener('click', function(event) {
@@ -249,6 +374,11 @@
         }
 
         var sizeButton = document.getElementsByClassName('ytp-size-button')[0];
+
+        if (!sizeButton) {
+            return;
+        }
+
         var sizeButtonHasTheaterModeTitle = theaterModeTitles.includes(sizeButton.getAttribute('data-title-no-tooltip'));
 
         if (theaterMode && sizeButtonHasTheaterModeTitle) {
@@ -268,7 +398,7 @@
     };
 
     // Update to given quality
-    var updateQuality = function (preferredQuality) {
+    var updateQuality = async function (preferredQuality) {
         if (preferredQuality === undefined) {
             preferredQuality = 'best-available';
             chrome.storage.sync.set({ preferredQuality: preferredQuality }, function () { });
@@ -276,58 +406,70 @@
 
         var settingsButton = document.getElementsByClassName('ytp-settings-button')[0];
 
-        settingsButton.click();
+        if (!settingsButton) {
+            return;
+        }
 
-        var buttons = document.getElementsByClassName('ytp-menuitem-label');
+        try {
+            openSettingsMenu(settingsButton);
 
-        for (var i = 0; i < buttons.length; i++) {
-            if (qualityTitles.includes(buttons[i].innerHTML)) {
-                buttons[i].click();
+            var qualityMenuLabel = await waitForValue(findQualityMenuLabel, menuWaitTimeout);
+
+            if (!qualityMenuLabel) {
+                throw new Error('Quality menu item was not found');
             }
+
+            clickMenuLabel(qualityMenuLabel);
+
+            var targetItems = await waitForValue(function() {
+                var items = getVisibleQualityLabels();
+                return items.length > 0 ? items : null;
+            }, menuWaitTimeout);
+
+            if (!targetItems) {
+                throw new Error('Quality options were not found');
+            }
+
+            var targetItem = preferredQuality === 'best-available'
+                ? findBestAvailableQuality(targetItems)
+                : findTargetItem(preferredQuality, targetItems);
+
+            if (!targetItem) {
+                throw new Error('Preferred quality was not found');
+            }
+
+            clickMenuLabel(targetItem);
+        } catch (error) {
+            console.log('Simple Auto HD could not update quality:', error);
+        } finally {
+            setTimeout(function() {
+                closeSettingsMenu(settingsButton);
+            }, menuCloseDelay);
         }
-
-        var targetItem;
-
-        var targetItems = document.querySelectorAll('.ytp-quality-menu .ytp-menuitem-label');
-        targetItems = Array.from(targetItems).filter(item => !item.innerHTML.includes("ytp-premium-label"));
-        
-        if (preferredQuality === 'best-available') {
-            targetItem = targetItems[0];
-        } else {
-            targetItem = findTargetItem(preferredQuality, targetItems);
-        }
-
-        targetItem.click();
     }
 
     // Find the target quality
     function findTargetItem(preferredQuality, targetItems) {
-        var targetItem = '';
-        
-        for (var i = 0; i < targetItems.length; i++) {
-            var potentialTargetItem = targetItems[i].childNodes[0].childNodes[0];
+        var key = qualitiesArray.indexOf(preferredQuality);
 
-            var quality = potentialTargetItem.innerHTML.split(' ')[0];
+        if (key === -1) {
+            return findBestAvailableQuality(targetItems);
+        }
 
-            if (quality === preferredQuality) {
-                targetItem = potentialTargetItem;
+        for (var i = key; i < qualitiesArray.length; i++) {
+            var targetItem = findQualityByName(qualitiesArray[i], targetItems);
+
+            if (targetItem) {
+                return targetItem;
             }
         }
 
-        var key = qualitiesArray.indexOf(preferredQuality);
-
-        if (targetItem === '' && (qualitiesArray[key + 1] !== undefined)) {
-            preferredQuality = qualitiesArray[key + 1];
-
-            return findTargetItem(preferredQuality, targetItems);
-        }
-
-        return targetItem;
+        return findBestAvailableQuality(targetItems);
     }
 
     // Listen for chrome storage changes
     chrome.storage.onChanged.addListener(function (changes, namespace) {
-        for (key in changes) {
+        for (var key in changes) {
             if (key === 'theaterMode') {
                 toggleTheaterMode();
             } else if (key === 'preferredQuality') {

--- a/docs/updated.html
+++ b/docs/updated.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Simple Auto HD Updated</title>
+  <style>
+    body {
+      margin: 0;
+      background: #f7f8fb;
+      color: #20242c;
+      font-family: Arial, Helvetica, sans-serif;
+      line-height: 1.5;
+    }
+
+    main {
+      box-sizing: border-box;
+      width: min(760px, 100%);
+      margin: 0 auto;
+      padding: 48px 24px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: 32px;
+      line-height: 1.2;
+    }
+
+    h2 {
+      margin: 32px 0 8px;
+      font-size: 20px;
+    }
+
+    p {
+      margin: 0 0 16px;
+    }
+
+    ol {
+      padding-left: 22px;
+    }
+
+    li {
+      margin: 8px 0;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Simple Auto HD has been updated to v2.0.7</h1>
+    <p>This update fixes quality selection after recent YouTube settings menu changes.</p>
+
+    <h2>Updates</h2>
+    <ol>
+      <li>Made the YouTube quality selector wait for the settings and quality menus to render before clicking.</li>
+      <li>Updated menu selection to use visible quality labels instead of relying on YouTube's previous nested DOM structure.</li>
+      <li>Added fallback handling so the settings menu is closed if quality selection cannot complete.</li>
+    </ol>
+  </main>
+</body>
+</html>

--- a/docs/updated.html
+++ b/docs/updated.html
@@ -33,6 +33,7 @@
 
     .project-name {
       margin: 0;
+      color: #fff;
       font-size: 3.25rem;
       line-height: 1.15;
     }
@@ -40,6 +41,7 @@
     .project-tagline {
       margin: 1rem auto 2rem;
       max-width: 760px;
+      color: rgba(255, 255, 255, 0.84);
       font-size: 1.25rem;
       font-weight: normal;
       opacity: 0.8;

--- a/docs/updated.html
+++ b/docs/updated.html
@@ -5,30 +5,90 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Simple Auto HD Updated</title>
   <style>
+    * {
+      box-sizing: border-box;
+    }
+
     body {
       margin: 0;
-      background: #f7f8fb;
-      color: #20242c;
-      font-family: Arial, Helvetica, sans-serif;
+      color: #606c71;
+      font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
       line-height: 1.5;
     }
 
-    main {
-      box-sizing: border-box;
-      width: min(760px, 100%);
+    .page-header {
+      color: #fff;
+      text-align: center;
+      background-color: #159957;
+      background-image: linear-gradient(120deg, #155799, #159957);
+      padding: 5rem 6rem;
+    }
+
+    .project-logo {
+      display: block;
+      width: 88px;
+      height: 88px;
+      margin: 0 auto 1.25rem;
+    }
+
+    .project-name {
+      margin: 0;
+      font-size: 3.25rem;
+      line-height: 1.15;
+    }
+
+    .project-tagline {
+      margin: 1rem auto 2rem;
+      max-width: 760px;
+      font-size: 1.25rem;
+      font-weight: normal;
+      opacity: 0.8;
+    }
+
+    .btn {
+      display: inline-block;
+      margin-bottom: 1rem;
+      color: rgba(255, 255, 255, 0.9);
+      background-color: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.28);
+      border-radius: 0.3rem;
+      padding: 0.75rem 1rem;
+      text-decoration: none;
+      transition: color 0.2s, background-color 0.2s, border-color 0.2s;
+    }
+
+    .btn:hover {
+      color: #fff;
+      background-color: rgba(255, 255, 255, 0.2);
+      border-color: rgba(255, 255, 255, 0.55);
+    }
+
+    .btn img {
+      width: 18px;
+      height: 18px;
+      margin-right: 0.45rem;
+      vertical-align: text-bottom;
+    }
+
+    .main-content {
+      max-width: 64rem;
       margin: 0 auto;
-      padding: 48px 24px;
+      padding: 2rem 6rem;
+      font-size: 1.1rem;
     }
 
     h1 {
-      margin: 0 0 12px;
-      font-size: 32px;
-      line-height: 1.2;
+      margin: 2rem 0 1rem;
+      color: #159957;
+      font-size: 2rem;
+      font-weight: normal;
     }
 
     h2 {
       margin: 32px 0 8px;
+      color: #159957;
       font-size: 20px;
+      font-weight: normal;
     }
 
     p {
@@ -42,11 +102,59 @@
     li {
       margin: 8px 0;
     }
+
+    .version {
+      font-weight: 700;
+    }
+
+    .site-footer {
+      max-width: 64rem;
+      margin: 0 auto;
+      padding: 2rem 6rem;
+      color: #819198;
+      font-size: 0.95rem;
+      border-top: solid 1px #eff0f1;
+    }
+
+    .site-footer a {
+      color: #1e6bb8;
+      text-decoration: none;
+    }
+
+    @media screen and (max-width: 42em) {
+      .page-header {
+        padding: 3rem 1rem;
+      }
+
+      .project-name {
+        font-size: 2rem;
+      }
+
+      .project-tagline {
+        font-size: 1rem;
+      }
+
+      .main-content,
+      .site-footer {
+        padding: 2rem 1rem;
+        font-size: 1rem;
+      }
+    }
   </style>
 </head>
 <body>
-  <main>
-    <h1>Simple Auto HD has been updated to v2.0.7</h1>
+  <header class="page-header">
+    <img class="project-logo" src="../sahd-128.png" alt="Simple Auto HD">
+    <h1 class="project-name">Simple Auto HD</h1>
+    <h2 class="project-tagline">Open source YouTube auto HD selector. Automatically selects the best available HD quality or your preferred quality.</h2>
+    <a class="btn" href="https://github.com/veredis/simple-auto-hd">
+      <img src="../github-mark-white.png" alt="">
+      View on GitHub
+    </a>
+  </header>
+
+  <main class="main-content">
+    <h1>Simple Auto HD has been updated to <span class="version">v2.0.7</span></h1>
     <p>This update fixes quality selection after recent YouTube settings menu changes.</p>
 
     <h2>Updates</h2>
@@ -56,5 +164,9 @@
       <li>Added fallback handling so the settings menu is closed if quality selection cannot complete.</li>
     </ol>
   </main>
+
+  <footer class="site-footer">
+    <a href="https://github.com/veredis/simple-auto-hd">simple-auto-hd</a> is maintained by <a href="https://github.com/veredis">veredis</a>.
+  </footer>
 </body>
 </html>

--- a/docs/updated.md
+++ b/docs/updated.md
@@ -1,8 +1,14 @@
-## Simple Auto HD has been updated to v2.0.5!
+## Simple Auto HD has been updated to v2.0.7!
 
-This chrome web store update includes both 2.0.4 and 2.0.5 updates at same time, rolled into one for convenience.
+This update fixes quality selection after recent YouTube settings menu changes.
 
-Latest version: v2.0.5 
+Latest version: v2.0.7
+### Updates:
+1. Made the YouTube quality selector wait for the settings and quality menus to render before clicking.
+2. Updated menu selection to use visible quality labels instead of relying on YouTube's previous nested DOM structure.
+3. Added fallback handling so the settings menu is closed if quality selection cannot complete.
+
+Older version: v2.0.5
 ### Updates:
 1. Fixed mutation observer issue in previous version to also use timeout for at least 100ms to make sure element is ready for manipulation.
 2. Added extension enable/disable feature from the popup menu.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "Simple Auto HD (Open Source)",
 	"description": "Simple Auto HD quality selector for YouTube. Up to 8k/4k (60fps/50fps/48fps/30fps) supported. Theater mode.",
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"author": "Sameer Nyaupane",
 
 	"icons": { 


### PR DESCRIPTION
Fixes YouTube quality settings menu from staying open after loading a video.

The extension now waits for the settings/quality menus to render, clicks the parent menu item instead of relying on the label DOM shape, selects quality by visible text, and closes the settings panel afterward.